### PR TITLE
Add endpoints for parametrized discovery query

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,7 +33,8 @@
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",
     "pg": "^8.11.3",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "zod": "^3.22.2"
   },
   "devDependencies": {
     "@l2beat/discovery-types": "^0.1.0",

--- a/packages/backend/src/api/controllers/discovery/DiscoveryController.ts
+++ b/packages/backend/src/api/controllers/discovery/DiscoveryController.ts
@@ -23,8 +23,8 @@ import {
 export class DiscoveryController {
   constructor(private readonly discoveryRepository: DiscoveryRepository) {}
 
-  async getDiscovery(): Promise<DiscoveryApi | undefined> {
-    const discovery = await this.discoveryRepository.find(ChainId.ETHEREUM)
+  async getDiscovery(chainId: ChainId): Promise<DiscoveryApi | undefined> {
+    const discovery = await this.discoveryRepository.find(chainId)
 
     if (!discovery) {
       return
@@ -33,8 +33,10 @@ export class DiscoveryController {
     return toDiscoveryApi(discovery.discoveryOutput)
   }
 
-  async getRawDiscovery(): Promise<DiscoveryOutput | undefined> {
-    const discovery = await this.discoveryRepository.find(ChainId.ETHEREUM)
+  async getRawDiscovery(
+    chainId: ChainId,
+  ): Promise<DiscoveryOutput | undefined> {
+    const discovery = await this.discoveryRepository.find(chainId)
 
     if (!discovery) {
       return

--- a/packages/backend/src/api/routes/discovery.ts
+++ b/packages/backend/src/api/routes/discovery.ts
@@ -1,14 +1,20 @@
 import Router from '@koa/router'
+import { ChainId, stringAs } from '@lz/libs'
+import { z } from 'zod'
 
 import { DiscoveryController } from '../controllers/discovery/DiscoveryController'
+import { withTypedContext } from './typedContext'
 
 export function createDiscoveryRouter(
   discoveryController: DiscoveryController,
 ): Router {
   const router = new Router()
 
+  /**
+   * @deprecated
+   */
   router.get('/discovery/raw', async (ctx): Promise<void> => {
-    const data = await discoveryController.getRawDiscovery()
+    const data = await discoveryController.getRawDiscovery(ChainId.ETHEREUM)
 
     if (!data) {
       ctx.status = 404
@@ -18,8 +24,11 @@ export function createDiscoveryRouter(
     ctx.body = data
   })
 
+  /**
+   * @deprecated
+   */
   router.get('/discovery', async (ctx): Promise<void> => {
-    const data = await discoveryController.getDiscovery()
+    const data = await discoveryController.getDiscovery(ChainId.ETHEREUM)
 
     if (!data) {
       ctx.status = 404
@@ -28,6 +37,44 @@ export function createDiscoveryRouter(
 
     ctx.body = data
   })
+
+  router.get(
+    '/discovery/:chainId',
+    withTypedContext(
+      z.object({
+        params: z.object({ chainId: stringAs((s) => ChainId(+s)) }),
+      }),
+      async (ctx): Promise<void> => {
+        const data = await discoveryController.getDiscovery(ctx.params.chainId)
+
+        if (!data) {
+          ctx.status = 404
+          return
+        }
+
+        ctx.body = data
+      },
+    ),
+  )
+
+  router.get(
+    '/discovery/raw/:chainId',
+    withTypedContext(
+      z.object({
+        params: z.object({ chainId: stringAs((s) => ChainId(+s)) }),
+      }),
+      async (ctx): Promise<void> => {
+        const data = await discoveryController.getDiscovery(ctx.params.chainId)
+
+        if (!data) {
+          ctx.status = 404
+          return
+        }
+
+        ctx.body = data
+      },
+    ),
+  )
 
   return router
 }

--- a/packages/backend/src/api/routes/discovery.ts
+++ b/packages/backend/src/api/routes/discovery.ts
@@ -64,7 +64,9 @@ export function createDiscoveryRouter(
         params: z.object({ chainId: stringAs((s) => ChainId(+s)) }),
       }),
       async (ctx): Promise<void> => {
-        const data = await discoveryController.getDiscovery(ctx.params.chainId)
+        const data = await discoveryController.getRawDiscovery(
+          ctx.params.chainId,
+        )
 
         if (!data) {
           ctx.status = 404

--- a/packages/backend/src/api/routes/typedContext.ts
+++ b/packages/backend/src/api/routes/typedContext.ts
@@ -1,0 +1,38 @@
+import { Middleware } from '@koa/router'
+import { Context, Request } from 'koa'
+import { z } from 'zod'
+
+interface ParsedRequest extends Request {
+  body?: unknown
+}
+
+interface ParsedContext extends Context {
+  request: ParsedRequest
+}
+
+export function withTypedContext<T extends z.AnyZodObject>(
+  parser: T,
+  handler: (ctx: ParsedContext & z.infer<T>) => Promise<void>,
+): Middleware {
+  return async (ctx) => {
+    const parseResult = parser.safeParse({
+      params: ctx.params,
+      query: ctx.query,
+      request: ctx.request,
+    })
+    if (!parseResult.success) {
+      ctx.status = 400
+      ctx.body = { issues: parseResult.error.issues }
+      return
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    ctx.params = parseResult.data.params
+    Object.defineProperty(ctx.request, 'body', {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      value: parseResult.data.request?.body,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    Object.defineProperty(ctx, 'query', { value: parseResult.data.query })
+    await handler(ctx)
+  }
+}

--- a/packages/libs/src/index.ts
+++ b/packages/libs/src/index.ts
@@ -1,3 +1,4 @@
+export * from './branded'
 export * from './Bytes'
 export * from './bytes32ToAddress'
 export * from './ChainId'


### PR DESCRIPTION
Resolves L2B-2524

## What's changed
Old endpoints are now deprecated but still in use, removal of those will happen along with switching frontend to the new variant.

