### PR TITLE
Fix conditional status delay rows

### DIFF
--- a/packages/frontend/src/view/components/status/Delays.tsx
+++ b/packages/frontend/src/view/components/status/Delays.tsx
@@ -29,15 +29,9 @@ export function Delays({ status }: { status: DiscoveryStatus }) {
   return (
     <>
       <SubsectionHeader title="Delays" />
-      {status.delays.blocks && (
-        <Row label="Blocks behind the tip" value={status.delays.blocks} />
-      )}
-      {status.delays.discovery && (
-        <Row label="Discovery blocks to tip" value={status.delays.discovery} />
-      )}
-      {status.delays.offset && (
-        <Row label="Offset between indexers" value={status.delays.offset} />
-      )}
+      <Row label="Blocks behind the tip" value={status.delays.blocks} />
+      <Row label="Discovery blocks to tip" value={status.delays.discovery} />
+      <Row label="Offset between indexers" value={status.delays.offset} />
     </>
   )
 }


### PR DESCRIPTION
Having no offset between indexers (0) causes condition to fail and row not to display