### PR TITLE
chore: return height that has been requested by the uif

### DIFF
--- a/packages/backend/src/indexers/BlockNumberIndexer.ts
+++ b/packages/backend/src/indexers/BlockNumberIndexer.ts
@@ -74,7 +74,7 @@ export class BlockNumberIndexer extends ChildIndexer {
       }
       await this.blockRepository.add(record)
 
-      return block.timestamp
+      return toTimestamp
     }
 
     if (this.reorgedBlocks.length > 0) {


### PR DESCRIPTION
In case of skipping reorgs, bn indexer was returning block timestamp instead of requested timestamp.
This in turn caused uif to detect height shift between the requested height and returned height, thus causing infinite loops in case of bigger intervals between the updates