### PR TITLE
Fix blockNumberRepository add function

### DIFF
--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -30,10 +30,21 @@ describe(BlockNumberRepository.name, () => {
     expect(await repository.getAll()).toEqual([])
   })
 
-  it('adds 1 records', async () => {
+  it('adds 1 record', async () => {
     const record = mockRecord(1)
     await repository.add(record)
     expect(await repository.getAll()).toEqual([record])
+  })
+
+  it('updates 1 record', async () => {
+    const record = mockRecord(1)
+    const redord2 = {
+      ...record,
+      blockHash: Hash256('0x' + '2'.padStart(64, '0')),
+    }
+    await repository.add(record)
+    await repository.add(redord2)
+    expect(await repository.getAll()).toEqual([redord2])
   })
 
   it('adds multiple records and queries them', async () => {

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -30,6 +30,12 @@ describe(BlockNumberRepository.name, () => {
     expect(await repository.getAll()).toEqual([])
   })
 
+  it('adds 1 records', async () => {
+    const record = mockRecord(1)
+    await repository.add(record)
+    expect(await repository.getAll()).toEqual([record])
+  })
+
   it('adds multiple records and queries them', async () => {
     const records: BlockNumberRecord[] = [
       mockRecord(1),

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -24,7 +24,7 @@ export class BlockNumberRepository extends BaseRepository {
     await knex('block_numbers')
       .insert(row)
       .returning('block_number')
-      .onConflict(['unix_timestamp', 'chain_id'])
+      .onConflict(['block_number', 'chain_id'])
       .merge()
 
     return row.block_number


### PR DESCRIPTION
Context: after changing the PK on block_numbers table, I forgot to change the onConflict constraint in blockNumberRepository add function. This PR will solve this issue, also adding a test to make sure we'll never do it again.