### PR TITLE
Discover only blocks with events

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
     "@l2beat/backend-tools": "^0.4.0",
-    "@l2beat/discovery": "^0.19.0",
+    "@l2beat/discovery": "^0.21.2",
     "@l2beat/uif": "^0.2.2",
     "@lz/libs": "*",
     "@sentry/node": "^7.73.0",

--- a/packages/backend/src/indexers/BlockNumberIndexer.test.ts
+++ b/packages/backend/src/indexers/BlockNumberIndexer.test.ts
@@ -270,13 +270,22 @@ const BLOCKS: BlockFromClient[] = [
   },
 ]
 
-function mockBlockNumberRepository(initialStorage: BlockNumberRecord[] = []) {
+export function mockBlockNumberRepository(
+  initialStorage: BlockNumberRecord[] = [],
+) {
   const blockNumberStorage: BlockNumberRecord[] = [...initialStorage]
 
   return mockObject<BlockNumberRepository>({
     findByNumber: async (number) =>
       blockNumberStorage.find((bnr) => bnr.blockNumber === number),
     findLast: async () => blockNumberStorage.at(-1),
+    findAtOrBefore: async (timestamp) =>
+      blockNumberStorage
+        .filter((bnr) => timestamp.gte(bnr.timestamp))
+        .sort((a, b) => b.timestamp.toNumber() - a.timestamp.toNumber())
+        .shift(),
+    getByTimestamp: async (timestamp) =>
+      blockNumberStorage.filter((bnr) => timestamp.equals(bnr.timestamp)),
     addMany: async (blocks: BlockNumberRecord[]) => {
       blockNumberStorage.push(...blocks)
       return blocks.length

--- a/packages/backend/src/indexers/DiscoveryIndexer.test.ts
+++ b/packages/backend/src/indexers/DiscoveryIndexer.test.ts
@@ -19,7 +19,7 @@ describe(DiscoveryIndexer.name, () => {
         hasOutputChanged: async () => false,
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
-        addOrUpdate: async () => true,
+        add: async () => true,
         findAtOrBefore: async () => undefined,
       })
       const chainId = ChainId.ETHEREUM
@@ -42,7 +42,7 @@ describe(DiscoveryIndexer.name, () => {
       expect(await discoveryIndexer.update(0, 1)).toEqual(1)
       expect(discoveryEngine.discover).toHaveBeenCalledTimes(1)
       expect(discoveryEngine.discover).toHaveBeenNthCalledWith(1, config, 1)
-      expect(discoveryRepository.addOrUpdate).toHaveBeenNthCalledWith(1, {
+      expect(discoveryRepository.add).toHaveBeenNthCalledWith(1, {
         chainId,
         blockNumber: 1,
         discoveryOutput: {
@@ -73,7 +73,7 @@ describe(DiscoveryIndexer.name, () => {
         hasOutputChanged: async () => false,
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
-        addOrUpdate: async () => true,
+        add: async () => true,
         findAtOrBefore: async () => prevDiscovery,
       })
 
@@ -94,7 +94,7 @@ describe(DiscoveryIndexer.name, () => {
 
       expect(await disocoveryIndexer.update(1, 2)).toEqual(2)
       expect(discoveryEngine.discover).toHaveBeenCalledTimes(0)
-      expect(discoveryRepository.addOrUpdate).not.toHaveBeenCalled()
+      expect(discoveryRepository.add).not.toHaveBeenCalled()
       expect(discoveryEngine.hasOutputChanged).toHaveBeenCalledTimes(1)
       expect(discoveryEngine.hasOutputChanged).toHaveBeenCalledWith(
         config,
@@ -112,7 +112,7 @@ describe(DiscoveryIndexer.name, () => {
         discover: async () => [],
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
-        addOrUpdate: async () => true,
+        add: async () => true,
       })
       const BLOCK_NUMBER = 10
 

--- a/packages/backend/src/indexers/DiscoveryIndexer.test.ts
+++ b/packages/backend/src/indexers/DiscoveryIndexer.test.ts
@@ -1,35 +1,53 @@
 import { Logger } from '@l2beat/backend-tools'
 import { DiscoveryConfig, DiscoveryEngine } from '@l2beat/discovery'
-import { DiscoveryOutput } from '@l2beat/discovery-types'
 import { ChainId, Hash256, UnixTime } from '@lz/libs'
 import { expect, mockObject } from 'earl'
 
-import { BlockNumberRepository } from '../peripherals/database/BlockNumberRepository'
+import {
+  BlockNumberRecord,
+  BlockNumberRepository,
+} from '../peripherals/database/BlockNumberRepository'
 import { DiscoveryRepository } from '../peripherals/database/DiscoveryRepository'
+import { EventRepository } from '../peripherals/database/EventRepository'
 import { IndexerStateRepository } from '../peripherals/database/IndexerStateRepository'
 import { CacheInvalidationIndexer } from './CacheInvalidationIndexer'
 import { DiscoveryIndexer } from './DiscoveryIndexer'
+import { EventIndexer } from './EventIndexer'
 
 describe(DiscoveryIndexer.name, () => {
   describe(DiscoveryIndexer.prototype.update.name, () => {
-    it('should run discovery on the latest block', async () => {
+    it('should run discovery on the latest block with event', async () => {
+      const chainId = ChainId.ETHEREUM
+      const BLOCK_100 = mockBlock({
+        blockNumber: 100,
+        timestamp: new UnixTime(1000),
+      })
       const config = mockConfig()
       const discoveryEngine = mockObject<DiscoveryEngine>({
         discover: async () => [],
-        hasOutputChanged: async () => false,
+      })
+      const blockRepo = mockObject<BlockNumberRepository>({
+        findAtOrBefore: async () => BLOCK_100,
+        findByNumber: async () => BLOCK_100,
+      })
+      const eventRepo = mockObject<EventRepository>({
+        getInRange: async () => [
+          {
+            chainId,
+            blockNumber: BLOCK_100.blockNumber,
+          },
+        ],
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
         add: async () => true,
         findAtOrBefore: async () => undefined,
       })
-      const chainId = ChainId.ETHEREUM
 
       const discoveryIndexer = new DiscoveryIndexer(
         discoveryEngine,
         config,
-        mockObject<BlockNumberRepository>({
-          findAtOrBefore: async () => mockBlock(1),
-        }),
+        blockRepo,
+        eventRepo,
         discoveryRepository,
         mockObject<IndexerStateRepository>(),
         chainId,
@@ -37,20 +55,35 @@ describe(DiscoveryIndexer.name, () => {
         mockObject<CacheInvalidationIndexer>({
           subscribe: () => {},
         }),
+        mockObject<EventIndexer>({
+          subscribe: () => {},
+        }),
       )
 
-      expect(await discoveryIndexer.update(0, 1)).toEqual(1)
+      expect(await discoveryIndexer.update(0, 2000)).toEqual(
+        BLOCK_100.timestamp.toNumber(),
+      )
+      expect(blockRepo.findByNumber).toHaveBeenCalledTimes(1)
+      expect(blockRepo.findByNumber).toHaveBeenNthCalledWith(
+        1,
+        BLOCK_100.blockNumber,
+        chainId,
+      )
       expect(discoveryEngine.discover).toHaveBeenCalledTimes(1)
-      expect(discoveryEngine.discover).toHaveBeenNthCalledWith(1, config, 1)
+      expect(discoveryEngine.discover).toHaveBeenNthCalledWith(
+        1,
+        config,
+        BLOCK_100.blockNumber,
+      )
       expect(discoveryRepository.add).toHaveBeenNthCalledWith(1, {
         chainId,
-        blockNumber: 1,
+        blockNumber: BLOCK_100.blockNumber,
         discoveryOutput: {
           version: 3,
           name: 'test',
           configHash: config.hash,
           chain: 'ethereum',
-          blockNumber: 1,
+          blockNumber: BLOCK_100.blockNumber,
           contracts: [],
           eoas: [],
           abis: {},
@@ -58,31 +91,27 @@ describe(DiscoveryIndexer.name, () => {
       })
     })
 
-    it('should run hasOutputChanged if previous discovery exists', async () => {
+    it('should not run discovery if no blocks with events', async () => {
       const config = mockConfig()
       const chainId = ChainId.ETHEREUM
-      const prevDiscovery = {
-        chainId,
-        blockNumber: 1,
-        discoveryOutput: mockObject<DiscoveryOutput>({
-          version: 3,
-        }),
-      }
       const discoveryEngine = mockObject<DiscoveryEngine>({
         discover: async () => [],
-        hasOutputChanged: async () => false,
+      })
+      const eventyRepo = mockObject<EventRepository>({
+        getInRange: async () => [],
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
         add: async () => true,
-        findAtOrBefore: async () => prevDiscovery,
       })
 
       const disocoveryIndexer = new DiscoveryIndexer(
         discoveryEngine,
         config,
         mockObject<BlockNumberRepository>({
-          findAtOrBefore: async () => mockBlock(1),
+          findAtOrBefore: async (timestamp: UnixTime) =>
+            mockBlock({ timestamp, blockNumber: timestamp.toNumber() / 1000 }),
         }),
+        eventyRepo,
         discoveryRepository,
         mockObject<IndexerStateRepository>(),
         chainId,
@@ -90,38 +119,38 @@ describe(DiscoveryIndexer.name, () => {
         mockObject<CacheInvalidationIndexer>({
           subscribe: () => {},
         }),
+        mockObject<EventIndexer>({
+          subscribe: () => {},
+        }),
       )
 
-      expect(await disocoveryIndexer.update(1, 2)).toEqual(2)
+      expect(await disocoveryIndexer.update(1000, 2000)).toEqual(2000)
       expect(discoveryEngine.discover).toHaveBeenCalledTimes(0)
       expect(discoveryRepository.add).not.toHaveBeenCalled()
-      expect(discoveryEngine.hasOutputChanged).toHaveBeenCalledTimes(1)
-      expect(discoveryEngine.hasOutputChanged).toHaveBeenCalledWith(
-        config,
-        prevDiscovery.discoveryOutput,
-        1,
-      )
+      expect(eventyRepo.getInRange).toHaveBeenCalledTimes(1)
+      expect(eventyRepo.getInRange).toHaveBeenNthCalledWith(1, 1, 2, chainId)
     })
   })
 
   describe(DiscoveryIndexer.prototype.invalidate.name, () => {
-    it('should not run discovery on the targetHeight', async () => {
+    it('should delete the records after targetHeight', async () => {
       const chainId = ChainId.ETHEREUM
       const config = mockConfig()
       const discoveryEngine = mockObject<DiscoveryEngine>({
         discover: async () => [],
       })
       const discoveryRepository = mockObject<DiscoveryRepository>({
-        add: async () => true,
+        deleteAfter: async () => 1,
       })
-      const BLOCK_NUMBER = 10
+      const BLOCK_10 = mockBlock({ blockNumber: 10 })
 
       const discoveryIndexer = new DiscoveryIndexer(
         discoveryEngine,
         config,
         mockObject<BlockNumberRepository>({
-          findAtOrBefore: async () => mockBlock(BLOCK_NUMBER),
+          findAtOrBefore: async () => BLOCK_10,
         }),
+        mockObject<EventRepository>(),
         discoveryRepository,
         mockObject<IndexerStateRepository>(),
         chainId,
@@ -129,10 +158,46 @@ describe(DiscoveryIndexer.name, () => {
         mockObject<CacheInvalidationIndexer>({
           subscribe: () => {},
         }),
+        mockObject<EventIndexer>({
+          subscribe: () => {},
+        }),
       )
 
-      expect(await discoveryIndexer.invalidate(1000)).toEqual(1000)
+      expect(await discoveryIndexer.invalidate(1000)).toEqual(
+        BLOCK_10.timestamp.toNumber(),
+      )
       expect(discoveryEngine.discover).toHaveBeenCalledTimes(0)
+      expect(discoveryRepository.deleteAfter).toHaveBeenCalledTimes(1)
+      expect(discoveryRepository.deleteAfter).toHaveBeenNthCalledWith(
+        1,
+        BLOCK_10.blockNumber,
+        chainId,
+      )
+    })
+
+    it('should run on empty repository', async () => {
+      const discoveryIndexer = new DiscoveryIndexer(
+        mockObject<DiscoveryEngine>(),
+        mockConfig(),
+        mockObject<BlockNumberRepository>({
+          findAtOrBefore: async () => undefined,
+        }),
+        mockObject<EventRepository>(),
+        mockObject<DiscoveryRepository>({
+          deleteAfter: async () => 1,
+        }),
+        mockObject<IndexerStateRepository>(),
+        ChainId.ETHEREUM,
+        Logger.SILENT,
+        mockObject<CacheInvalidationIndexer>({
+          subscribe: () => {},
+        }),
+        mockObject<EventIndexer>({
+          subscribe: () => {},
+        }),
+      )
+
+      await discoveryIndexer.invalidate(0)
     })
   })
 })
@@ -147,11 +212,12 @@ function mockConfig() {
   })
 }
 
-function mockBlock(number: number) {
+function mockBlock(block: Partial<BlockNumberRecord>) {
   return {
-    blockNumber: number,
+    blockNumber: 1,
     blockHash: Hash256.random(),
     timestamp: new UnixTime(1),
     chainId: ChainId.ETHEREUM,
+    ...block,
   }
 }

--- a/packages/backend/src/indexers/DiscoveryIndexer.test.ts
+++ b/packages/backend/src/indexers/DiscoveryIndexer.test.ts
@@ -259,7 +259,7 @@ describe(DiscoveryIndexer.name, () => {
         }),
       )
 
-      await discoveryIndexer.invalidate(0)
+      await expect(discoveryIndexer.invalidate(0)).not.toBeRejected()
     })
   })
 })

--- a/packages/backend/src/modules/DiscoveryModule.ts
+++ b/packages/backend/src/modules/DiscoveryModule.ts
@@ -199,11 +199,13 @@ export function createDiscoverySubmodule(
     discoveryEngine,
     config.discovery,
     repositories.blockNumber,
+    repositories.events,
     repositories.discovery,
     repositories.indexerState,
     chainId,
     logger,
     cacheInvalidationIndexer,
+    eventIndexer,
   )
 
   const currDiscoveryIndexer = new CurrentDiscoveryIndexer(

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -138,7 +138,7 @@ describe(BlockNumberRepository.name, () => {
     const now = UnixTime.now()
     const blocks = new Array(2).fill(null).map((_, i) => ({
       blockNumber: i,
-      blockHash: Hash256('0x' + i.toString(16).padStart(64, '0')),
+      blockHash: Hash256.random(),
       timestamp: now,
       chainId: ChainId.ETHEREUM,
     }))

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -133,6 +133,24 @@ describe(BlockNumberRepository.name, () => {
 
     expect(await repository.getAll()).toEqual(blocks)
   })
+
+  it('gets blocks by timestamp', async () => {
+    const now = UnixTime.now()
+    const blocks = new Array(2).fill(null).map((_, i) => ({
+      blockNumber: i,
+      blockHash: Hash256('0x' + i.toString(16).padStart(64, '0')),
+      timestamp: now,
+      chainId: ChainId.ETHEREUM,
+    }))
+
+    await repository.addMany(blocks)
+    const block = mockRecord(69420)
+    await repository.addMany([block])
+
+    expect(await repository.getByTimestamp(now, ChainId.ETHEREUM)).toEqual(
+      blocks,
+    )
+  })
 })
 
 function mockRecord(blockNumber: number, now?: UnixTime): BlockNumberRecord {

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -57,6 +57,18 @@ export class BlockNumberRepository extends BaseRepository {
     return rows.map(toRecord)
   }
 
+  async getByTimestamp(
+    timestamp: UnixTime,
+    chainId: ChainId,
+  ): Promise<BlockNumberRecord[]> {
+    const knex = await this.knex()
+    const rows = await knex('block_numbers')
+      .select('*')
+      .where('chain_id', '=', Number(chainId))
+      .where('unix_timestamp', '=', timestamp.toDate())
+    return rows.map(toRecord)
+  }
+
   async findLast(chainId: ChainId): Promise<BlockNumberRecord | undefined> {
     const knex = await this.knex()
     const row = await knex('block_numbers')

--- a/packages/backend/src/peripherals/database/DiscoveryRepository.test.ts
+++ b/packages/backend/src/peripherals/database/DiscoveryRepository.test.ts
@@ -27,7 +27,7 @@ describe(DiscoveryRepository.name, () => {
   }
 
   it('adds single record and queries it', async () => {
-    await repository.addOrUpdate(record)
+    await repository.add(record)
 
     const actual = await repository.findAtOrBefore(record.blockNumber, chainId)
 
@@ -35,17 +35,28 @@ describe(DiscoveryRepository.name, () => {
   })
 
   it('does not override existing records', async () => {
-    await repository.addOrUpdate(record)
-    await repository.addOrUpdate(record2)
+    await repository.add(record)
+    await repository.add(record2)
 
     const actual = await repository.getAll()
 
     expect(actual).toEqual([record, record2])
   })
 
+  it('deletes records after given block number', async () => {
+    await repository.add(record)
+    await repository.add(record2)
+
+    await repository.deleteAfter(1, chainId)
+
+    const actual = await repository.getAll()
+
+    expect(actual).toEqual([record])
+  })
+
   it('delete all records', async () => {
-    await repository.addOrUpdate(record)
-    await repository.addOrUpdate(record2)
+    await repository.add(record)
+    await repository.add(record2)
 
     await repository.deleteAll()
 

--- a/packages/backend/src/peripherals/database/DiscoveryRepository.test.ts
+++ b/packages/backend/src/peripherals/database/DiscoveryRepository.test.ts
@@ -47,7 +47,7 @@ describe(DiscoveryRepository.name, () => {
     await repository.add(record)
     await repository.add(record2)
 
-    await repository.deleteAfter(1, chainId)
+    await repository.deleteAfter(record.blockNumber, chainId)
 
     const actual = await repository.getAll()
 

--- a/packages/backend/src/peripherals/database/DiscoveryRepository.ts
+++ b/packages/backend/src/peripherals/database/DiscoveryRepository.ts
@@ -18,7 +18,7 @@ export class DiscoveryRepository extends BaseRepository {
     this.autoWrap(this)
   }
 
-  async addOrUpdate(record: DiscoveryRecord): Promise<boolean> {
+  async add(record: DiscoveryRecord): Promise<boolean> {
     const row = toRow(record)
     const knex = await this.knex()
     await knex('discovery').insert(row)
@@ -41,6 +41,14 @@ export class DiscoveryRepository extends BaseRepository {
     const knex = await this.knex()
     const rows = await knex('discovery').select('*')
     return rows.map(toRecord)
+  }
+
+  async deleteAfter(blockNumber: number, chainId: ChainId): Promise<number> {
+    const knex = await this.knex()
+    return knex('discovery')
+      .where('chain_id', Number(chainId))
+      .andWhere('block_number', '>', blockNumber)
+      .delete()
   }
 
   async deleteAll(): Promise<number> {

--- a/packages/backend/src/peripherals/database/EventRepository.test.ts
+++ b/packages/backend/src/peripherals/database/EventRepository.test.ts
@@ -23,7 +23,7 @@ describe(EventRepository.name, () => {
     expect(actual).toEqual([record])
   })
 
-  it('gets records in range', async () => {
+  it('gets records in range, sorted', async () => {
     const records = Array.from({ length: 10 }, (_, i) => i * 2).map(
       (blockNumber) => ({
         blockNumber,
@@ -31,10 +31,20 @@ describe(EventRepository.name, () => {
       }),
     )
     await repository.addMany(records)
-    const actual = await repository.getInRange(2, 6, chainId)
+    await repository.addMany([
+      {
+        blockNumber: 5,
+        chainId,
+      },
+    ])
+    const actual = await repository.getSortedInRange(2, 6, chainId)
     expect(actual).toEqual([
       {
         blockNumber: 4,
+        chainId,
+      },
+      {
+        blockNumber: 5,
         chainId,
       },
       {

--- a/packages/backend/src/peripherals/database/EventRepository.ts
+++ b/packages/backend/src/peripherals/database/EventRepository.ts
@@ -27,7 +27,7 @@ export class EventRepository extends BaseRepository {
    * @param fromBlock exclusive
    * @param toBlock inclusive
    */
-  async getInRange(
+  async getSortedInRange(
     fromBlock: number,
     toBlock: number,
     chainId: ChainId,
@@ -37,6 +37,7 @@ export class EventRepository extends BaseRepository {
       .where('chain_id', Number(chainId))
       .andWhere('block_number', '>', fromBlock)
       .andWhere('block_number', '<=', toBlock)
+      .orderBy('block_number', 'asc')
 
     return rows.map(toRecord)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,6 +750,15 @@
     dotenv "^16.3.1"
     error-stack-parser "^2.1.4"
 
+"@l2beat/backend-tools@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@l2beat/backend-tools/-/backend-tools-0.5.0.tgz#3e30bb48cbbe204872650262bc0c05296321950f"
+  integrity sha512-OxKroHoFBYuxsnhsY0e+XLmHMB1e2M1kAc2l+yWzjJDKou6ivfbdeBcI78q4lKLsWcDoypN2zK1Vtw0deUW44A==
+  dependencies:
+    chalk "^4.1.2"
+    dotenv "^16.3.1"
+    error-stack-parser "^2.1.4"
+
 "@l2beat/discovery-types@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.4.1.tgz#174be097d96a9e5b3dd0ba61e88b35642e70c2e5"
@@ -757,12 +766,12 @@
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.19.0.tgz#8e1fa5863e80bbfb58cb73077b16017b67cfe445"
-  integrity sha512-bdGmvsAdcbYQqPn0cknw3ne0uyN0LkzV4t7s8WjzVhLGiZnY6qWuMd389t3cei4lneCGEDkG9LuJ5CAW6tcYtg==
+"@l2beat/discovery@^0.21.2":
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.21.2.tgz#a09a0f2438e409f075d027112b57251c7986ba21"
+  integrity sha512-UFV1ea3b2Q3pNJEcmb/kCvPDhEAF+8Y0041Qqi2p4Y1QEsPk4Ii9s6Gr47nBzXabI+xTbgdaezRUtxAIVZdKEw==
   dependencies:
-    "@l2beat/backend-tools" "^0.4.0"
+    "@l2beat/backend-tools" "^0.5.0"
     "@l2beat/discovery-types" "^0.4.1"
     chalk "^4.1.2"
     deep-diff "^1.0.2"


### PR DESCRIPTION
Resolves L2B-2864

### Issues
The issue arose when trying to synchronize Arbitrum's changelog using an EventIndexer, which signals when to run discovery based on emitted events indicating a change in contract configuration. The DiscoveryIndexer was designed to trigger discovery on the earliest event in the list. However, a problem was encountered due to the use of UnixTimestamps to represent safeHeight. In Arbitrum, multiple blocks can have the same timestamp. As a result, when discovery was run on block 7934557 and its timestamp was marked as completed, it overlooked events in blocks 7934560 and 7934564 because they shared the same timestamp. This issue underscores the challenges of using timestamps as heights in the UIF framework. It's suggested that this approach be reconsidered for future projects to prevent unforeseen issues. The underlying problem was a bug introduced unintentionally, but the framework could potentially be improved to prevent such errors.