### PR TITLE
Make discovery indexer configurable

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
     "@l2beat/backend-tools": "^0.4.0",
-    "@l2beat/discovery": "^0.21.2",
+    "@l2beat/discovery": "^0.21.3",
     "@l2beat/discovery-types": "^0.4.1",
     "@l2beat/uif": "^0.2.2",
     "@lz/libs": "*",

--- a/packages/backend/src/config/discovery/arbitrum.ts
+++ b/packages/backend/src/config/discovery/arbitrum.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const arbitrumRawConfig = createConfigFromTemplate({
   chain: ChainId.ARBITRUM,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/avalanche.ts
+++ b/packages/backend/src/config/discovery/avalanche.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const avalancheRawConfig = createConfigFromTemplate({
   chain: ChainId.AVALANCHE,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/base.ts
+++ b/packages/backend/src/config/discovery/base.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const baseRawConfig = createConfigFromTemplate({
   chain: ChainId.BASE,
-  initialAddresses: [
-    '0x38dE71124f7a447a01D67945a51eDcE9FF491251', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/bsc.ts
+++ b/packages/backend/src/config/discovery/bsc.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const bscRawConfig = createConfigFromTemplate({
   chain: ChainId.BSC,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/celo.ts
+++ b/packages/backend/src/config/discovery/celo.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const celoRawConfig = createConfigFromTemplate({
   chain: ChainId.CELO,
-  initialAddresses: [
-    '0x377530cdA84DFb2673bF4d145DCF0C4D7fdcB5b6', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/ethereum.ts
+++ b/packages/backend/src/config/discovery/ethereum.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const ethereumRawConfig = createConfigFromTemplate({
   chain: ChainId.ETHEREUM,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/linea.ts
+++ b/packages/backend/src/config/discovery/linea.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const lineaRawConfig = createConfigFromTemplate({
   chain: ChainId.LINEA,
-  initialAddresses: [
-    '0x38de71124f7a447a01d67945a51edce9ff491251', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/optimism.ts
+++ b/packages/backend/src/config/discovery/optimism.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const optimismRawConfig = createConfigFromTemplate({
   chain: ChainId.OPTIMISM,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/polygon-pos.ts
+++ b/packages/backend/src/config/discovery/polygon-pos.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const polygonPosRawConfig = createConfigFromTemplate({
   chain: ChainId.POLYGON_POS,
-  initialAddresses: [
-    '0x4D73AdB72bC3DD368966edD0f0b2148401A178E2', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/config/discovery/polygon-zkevm.ts
+++ b/packages/backend/src/config/discovery/polygon-zkevm.ts
@@ -13,9 +13,7 @@ const addresses = {
 
 const polygonZkEvmRawConfig = createConfigFromTemplate({
   chain: ChainId.POLYGON_ZKEVM,
-  initialAddresses: [
-    '0xFe7C30860D01e28371D40434806F4A8fcDD3A098', // UltraLightNodeV2
-  ],
+  initialAddresses: [addresses.endpoint, addresses.ultraLightNodeV2],
   addresses,
 })
 

--- a/packages/backend/src/indexers/DiscoveryIndexer.ts
+++ b/packages/backend/src/indexers/DiscoveryIndexer.ts
@@ -35,6 +35,17 @@ export class DiscoveryIndexer extends ChildIndexer {
     ])
   }
 
+  override async start(): Promise<void> {
+    const oldConfigHash = (
+      await this.indexerStateRepository.findById(this.id, this.chainId)
+    )?.configHash
+    const newConfigHash = this.config.hash
+    if (oldConfigHash !== newConfigHash) {
+      await this.setSafeHeight(0)
+    }
+    await super.start()
+  }
+
   async update(fromTimestamp: number, toTimestamp: number): Promise<number> {
     const [fromBlock, toBlock] = await Promise.all([
       this.blockNumberRepository.findAtOrBefore(
@@ -134,6 +145,7 @@ export class DiscoveryIndexer extends ChildIndexer {
       id: this.id,
       height,
       chainId: this.chainId,
+      configHash: this.config.hash,
     })
   }
 }

--- a/packages/backend/src/indexers/DiscoveryIndexer.ts
+++ b/packages/backend/src/indexers/DiscoveryIndexer.ts
@@ -40,9 +40,11 @@ export class DiscoveryIndexer extends ChildIndexer {
       await this.indexerStateRepository.findById(this.id, this.chainId)
     )?.configHash
     const newConfigHash = this.config.hash
+
     if (oldConfigHash !== newConfigHash) {
       await this.setSafeHeight(0)
     }
+
     await super.start()
   }
 

--- a/packages/backend/src/peripherals/database/IndexerStateRepository.ts
+++ b/packages/backend/src/peripherals/database/IndexerStateRepository.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@l2beat/backend-tools'
-import { ChainId } from '@lz/libs'
+import { ChainId, Hash256 } from '@lz/libs'
 import type { IndexerStateRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
@@ -9,6 +9,7 @@ export interface IndexerStateRecord {
   id: string // TODO: Maybe branded string?
   height: number
   chainId: ChainId
+  configHash?: Hash256
 }
 
 export class IndexerStateRepository extends BaseRepository {
@@ -57,6 +58,7 @@ function toRow(record: IndexerStateRecord): IndexerStateRow {
     height: record.height,
     last_updated: new Date(),
     chain_id: Number(record.chainId),
+    config_hash: record.configHash?.toString(),
   }
 }
 
@@ -65,5 +67,6 @@ function toRecord(row: IndexerStateRow): IndexerStateRecord {
     id: row.id,
     height: row.height,
     chainId: ChainId(row.chain_id),
+    configHash: row.config_hash ? Hash256(row.config_hash) : undefined,
   }
 }

--- a/packages/backend/src/peripherals/database/migrations/013_discovery_config_hash.ts
+++ b/packages/backend/src/peripherals/database/migrations/013_discovery_config_hash.ts
@@ -1,0 +1,26 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('indexer_states', (table) => {
+    table.string('config_hash').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('indexer_states', (table) => {
+    table.dropColumn('config_hash')
+  })
+}

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -19,6 +19,7 @@ declare module 'knex/types/tables' {
     height: number
     last_updated: Date
     chain_id: number
+    config_hash?: string
   }
 
   interface DiscoveryRow {

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,10 +766,10 @@
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@^0.21.2":
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.21.2.tgz#a09a0f2438e409f075d027112b57251c7986ba21"
-  integrity sha512-UFV1ea3b2Q3pNJEcmb/kCvPDhEAF+8Y0041Qqi2p4Y1QEsPk4Ii9s6Gr47nBzXabI+xTbgdaezRUtxAIVZdKEw==
+"@l2beat/discovery@^0.21.3":
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.21.3.tgz#1d93b32d64691cc182b62e9e1ed258c1505b6c48"
+  integrity sha512-b+sKUtMNxEKUD4JXMuUk7w4tDkHS32dQ2aoLqKOinaZUN5qxpnLhNuWWJNWYPSER0vefsJWyVdD99jo3kh3EFw==
   dependencies:
     "@l2beat/backend-tools" "^0.5.0"
     "@l2beat/discovery-types" "^0.4.1"


### PR DESCRIPTION
This PR also updates the discovery configuration which will make all the DiscoveryIndexers invalidate to 0. This is not really problematic as we have cache anyway.