### PR TITLE
Migrate avalanche to routescan explorer

### DIFF
--- a/packages/backend/src/config/config.common.ts
+++ b/packages/backend/src/config/config.common.ts
@@ -166,7 +166,7 @@ export function getCommonDiscoveryConfig(env: Env): Config['discovery'] {
          */
         chainNamePrefix: 'AVALANCHE',
         startBlock: 12126063,
-        blockExplorerPrefix: 'SNOWTRACE',
+        blockExplorerPrefix: 'AVALANCHE_ROUTESCAN',
         blockExplorerApiUrl:
           'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api',
         blockExplorerMinTimestamp: new Date('2020-09-23T11:02:00Z'),
@@ -177,6 +177,7 @@ export function getCommonDiscoveryConfig(env: Env): Config['discovery'] {
         unsupportedEtherscanMethods: {
           getContractCreation: true,
         },
+        explorerApiKeyRequired: false,
       }),
       linea: createConfig({
         /**
@@ -242,6 +243,7 @@ function configFromTemplate(env: Env) {
     changelogWhitelist,
     multicallConfig,
     unsupportedEtherscanMethods,
+    explorerApiKeyRequired = true,
   }: {
     /**
      * The prefix of the environment variables that configure the chain.
@@ -292,6 +294,11 @@ function configFromTemplate(env: Env) {
      * Etherscan unsupported methods
      */
     unsupportedEtherscanMethods?: EtherscanUnsupportedMethods
+
+    /**
+     * Whether the block explorer API key is required
+     */
+    explorerApiKeyRequired?: boolean
   }): DiscoverySubmoduleConfig {
     const isEnabled = env.boolean(`${chainNamePrefix}_DISCOVERY_ENABLED`, false)
     const isVisible = env.boolean(`${chainNamePrefix}_VISIBLE`, false)
@@ -320,7 +327,9 @@ function configFromTemplate(env: Env) {
           `${chainNamePrefix}_EVENT_INDEXER_AMT_BATCHES`,
         ),
         blockExplorerApiUrl,
-        blockExplorerApiKey: env.string(`${blockExplorerPrefix}_API_KEY`),
+        blockExplorerApiKey: explorerApiKeyRequired
+          ? env.string(`${blockExplorerPrefix}_API_KEY`)
+          : '',
         blockExplorerMinTimestamp: new UnixTime(
           env.integer(
             `${blockExplorerPrefix}_MIN_TIMESTAMP`,

--- a/packages/backend/src/config/config.common.ts
+++ b/packages/backend/src/config/config.common.ts
@@ -167,12 +167,16 @@ export function getCommonDiscoveryConfig(env: Env): Config['discovery'] {
         chainNamePrefix: 'AVALANCHE',
         startBlock: 12126063,
         blockExplorerPrefix: 'SNOWTRACE',
-        blockExplorerApiUrl: 'https://api.snowtrace.io/api',
+        blockExplorerApiUrl:
+          'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api',
         blockExplorerMinTimestamp: new Date('2020-09-23T11:02:00Z'),
         discoveryConfig: avalancheDiscoveryConfig,
         eventsToWatchConfig: avalancheEventsToWatch,
         changelogWhitelist: avalancheChangelogWhitelist,
         multicallConfig: multicallConfig.avalanche,
+        unsupportedEtherscanMethods: {
+          getContractCreation: true,
+        },
       }),
       linea: createConfig({
         /**


### PR DESCRIPTION
Resolves L2B-3042

Issues with invalid block order was caused by corrupted data inside database. Nothing related to logic itself.