### PR TITLE
Derive multisig ownership history based on past transactions and latest discovery output

### DIFF
--- a/packages/frontend/src/view/components/safe/utils.ts
+++ b/packages/frontend/src/view/components/safe/utils.ts
@@ -1,4 +1,5 @@
 import {
+  SafeMultisigTransaction,
   SafeTransactionDecodedData,
   SafeTransactionDecodedParam,
 } from '@lz/libs'
@@ -112,4 +113,115 @@ export function paramToSummary(param: Param): string {
 export function toUTC(dateString: string): string {
   const date = new Date(dateString)
   return date.toUTCString()
+}
+
+export function getDecodedProperties(tx: SafeMultisigTransaction) {
+  const parsingResult = SafeTransactionDecodedData.safeParse(tx.dataDecoded)
+
+  if (parsingResult.success && tx.dataDecoded) {
+    // SafeApi kit typings are wrong, string type applies only for transport layer
+    // string is later parsed into json object
+    const decodedCall = decodeCall(
+      tx.dataDecoded as unknown as NonNullable<SafeTransactionDecodedData>,
+    )
+
+    return {
+      method: decodedCall.method,
+      signature: decodedCall.signature,
+      callWithParams: decodedCall.functionCall,
+      params: decodedCall.params,
+    }
+  }
+
+  return null
+}
+
+export type MultisigOwnershipHistory = ReturnType<
+  typeof deriveMultisigOwnership
+>
+
+export function deriveMultisigOwnership(
+  allTransactions: SafeMultisigTransaction[],
+  latestOwners: number,
+) {
+  const ownerChangingTransactions = allTransactions
+    .map((tx) => ({ raw: tx, decoded: getDecodedProperties(tx) }))
+    .filter(
+      (ownerModification) =>
+        (ownerModification.decoded?.method === 'addOwnerWithThreshold' ||
+          ownerModification.decoded?.method === 'removeOwner') &&
+        ownerModification.raw.isExecuted,
+    )
+
+  // We start with the latest data so we yet don't know
+  // how long it will be applicable for
+  const ownerUpdates = [
+    {
+      toBlock: Infinity,
+      toTimestamp: Infinity,
+      owners: latestOwners,
+    },
+  ]
+
+  let lastAmountOfOwners = latestOwners
+
+  for (const ownerModification of ownerChangingTransactions) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const toBlock = ownerModification.raw.blockNumber!
+    const toTimestamp = new Date(ownerModification.raw.submissionDate).valueOf()
+
+    // Inc/Dev reversed since we are descending down the line
+    if (ownerModification.decoded?.method === 'addOwnerWithThreshold') {
+      ownerUpdates.push({
+        toTimestamp,
+        toBlock,
+        owners: --lastAmountOfOwners,
+      })
+    }
+
+    if (ownerModification.decoded?.method === 'removeOwner') {
+      ownerUpdates.push({
+        toTimestamp,
+        toBlock,
+        owners: ++lastAmountOfOwners,
+      })
+    }
+  }
+
+  // Invert and reassign toBlock and toTimestamp
+  // to achieve ascending order thus easier usage
+  const reversed = [...ownerUpdates].reverse()
+
+  const updateHistory = [
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    { fromBlock: 0, fromTimestamp: 0, owners: reversed.at(0)!.owners },
+  ]
+
+  for (let i = 1; i < reversed.length; i++) {
+    const tx = reversed[i]
+    updateHistory.push({
+      /* eslint-disable @typescript-eslint/no-non-null-assertion */
+      fromTimestamp: reversed[i - 1]!.toTimestamp,
+      fromBlock: reversed[i - 1]!.toBlock,
+      owners: tx!.owners,
+      /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    })
+  }
+
+  return updateHistory
+}
+
+export function getOwnershipForTransaction(
+  history: MultisigOwnershipHistory,
+  submissionDate: string,
+) {
+  const ownershipForTime = history
+    .sort((a, b) => b.fromTimestamp - a.fromTimestamp)
+    .find((update) => update.fromTimestamp < new Date(submissionDate).valueOf())
+
+  if (!ownershipForTime) {
+    throw new Error('Ownership for time not found')
+  }
+
+  return ownershipForTime.owners
 }

--- a/packages/frontend/src/view/components/safe/utils.ts
+++ b/packages/frontend/src/view/components/safe/utils.ts
@@ -220,7 +220,7 @@ export function getOwnershipForTransaction(
     .find((update) => update.fromTimestamp < new Date(submissionDate).valueOf())
 
   if (!ownershipForTime) {
-    throw new Error('Ownership for time not found')
+    throw new Error('Ownership for given time range not found')
   }
 
   return ownershipForTime.owners


### PR DESCRIPTION
Resolves L2B-3124

## What's changed

Ownership history is derived from internal multi-sig transactions.
I reorganized a few things, but nothing breaking was introduced.

## Notes

We could fire `getDecodedProperties` only once, now we do that in `2 * amount of txs` manner. We ain't need optimizations for now