### PR TITLE
Call super.start() in the end of start method in the indexer

### DIFF
--- a/packages/backend/src/indexers/BlockNumberIndexer.ts
+++ b/packages/backend/src/indexers/BlockNumberIndexer.ts
@@ -39,11 +39,11 @@ export class BlockNumberIndexer extends ChildIndexer {
   }
 
   override async start(): Promise<void> {
-    await super.start()
-
     this.lastKnownNumber =
       (await this.blockRepository.findLast(this.chainId))?.blockNumber ??
       this.startBlock
+
+    await super.start()
   }
 
   async update(_fromBlock: number, toBlock: number): Promise<number> {


### PR DESCRIPTION
This should fix the following error: 
<img width="651" alt="Screenshot 2024-02-12 at 11 36 31" src="https://github.com/l2beat/lz-monitoring/assets/38423054/2b5235f0-ca13-4d77-b2db-635c4021f623">
